### PR TITLE
Add maxlines option

### DIFF
--- a/android/src/main/java/com/reactnativemeasuretextsize/MeasureTextSizeModule.kt
+++ b/android/src/main/java/com/reactnativemeasuretextsize/MeasureTextSizeModule.kt
@@ -4,11 +4,8 @@ import android.annotation.SuppressLint
 import android.graphics.Typeface
 import android.graphics.text.LineBreaker
 import android.os.Build
-import android.text.Layout
+import android.text.*
 import android.text.Spannable.SPAN_INCLUSIVE_INCLUSIVE
-import android.text.SpannableStringBuilder
-import android.text.StaticLayout
-import android.text.TextPaint
 import android.text.style.AbsoluteSizeSpan
 import android.util.Log
 import com.facebook.react.bridge.*
@@ -40,7 +37,7 @@ class MeasureTextSizeModule(reactContext: ReactApplicationContext) :
     val fontSize = if (options.hasKey("fontSize")) options.getDouble("fontSize").toFloat() else 14f
     val lineHeight =
       if (options.hasKey("lineHeight")) options.getDouble("lineHeight")
-        .toFloat() else null
+        .toFloat() else 0f
     val fontFamily = getString(options, "fontFamily")
     val fontWeight = getString(options, "fontWeight")
     val fontStyle = getString(options, "fontStyle")
@@ -59,7 +56,7 @@ class MeasureTextSizeModule(reactContext: ReactApplicationContext) :
         end,
         SPAN_INCLUSIVE_INCLUSIVE
       )
-      if (lineHeight != null) {
+      if (lineHeight > 0) {
         spannable.setSpan(
           CustomLineHeightSpan(spToPx(lineHeight)),
           0, end, SPAN_INCLUSIVE_INCLUSIVE
@@ -95,6 +92,14 @@ class MeasureTextSizeModule(reactContext: ReactApplicationContext) :
             .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_FULL)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
           builder = builder.setUseLineSpacingFromFallbacks(true)
+        }
+        val maxLines =
+          if (options.hasKey("maxLines")) options.getInt("maxLines") else 0
+
+        if (maxLines > 0) {
+          builder = builder
+            .setMaxLines(maxLines)
+            .setEllipsize(TextUtils.TruncateAt.END)
         }
         builder.build()
       }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,8 +18,34 @@ const textSpec = {
 
 const width = 275;
 
+const renderLines = (heights: number[], texts: string[], maxLines?: number) => {
+  return (
+    <>
+      {heights.length > 0 &&
+        texts.map((t, i) => (
+          <View key={i} style={styles.textContainer}>
+            <View
+              style={[
+                styles.textWrapper,
+                {
+                  height: heights[i],
+                },
+              ]}
+            >
+              <Text style={[styles.text]} numberOfLines={maxLines}>
+                {t}
+              </Text>
+            </View>
+          </View>
+        ))}
+    </>
+  );
+};
+
 export default function App() {
   const [heights, setHeights] = useState<number[]>([]);
+  const [twoLinesHeights, setTwoLinesHeights] = useState<number[]>([]);
+
   const texts = useMemo(
     () => [
       'Hello, gg',
@@ -36,8 +62,16 @@ export default function App() {
       'For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, Date conversion is not supported out of the box.' +
         'For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, Date conversion is not supported out of the box.' +
         `For argument types not listed above,
-        
          you will need to handle the conversion yourself. For example, in Android, Date conversion is not supported out of the box.`,
+    ],
+    []
+  );
+
+  const twoLinesTexts = useMemo(
+    () => [
+      '၂၀၂၁ ခုနှစ် ဇူလိုင် ၂၇ ရက်တွင် မြန်မာနိုင်ငံတော်ဗဟိုဘဏ်က နိုင်ငံခြားငွေစျေးပြိုင်လေလံဖြင့် ဒေါ်လာသုံးသန်း ထပ်မံရောင်းချခဲ့ပြီး ဇူလိုင်လတစ်လနီးပါးတွင် ဒေါ်လာ ကိုးကြိမ်ရောင်းချခဲ့ပြီး ဒေါ်လာသန်း ၃၀ အထိ စံချိန်တင်ရောင်းချခဲ့ခြင်း ဖြစ်ကြောင်း သိရသည်။',
+      `For argument types not listed above,
+       you will need to handle the conversion yourself. For example, in Android, Date conversion is not supported out of the box.`,
     ],
     []
   );
@@ -51,8 +85,17 @@ export default function App() {
       });
 
       setHeights(rr);
+
+      const rr2 = await measureHeights({
+        texts: twoLinesTexts,
+        maxLines: 2,
+        width,
+        ...textSpec,
+      });
+
+      setTwoLinesHeights(rr2);
     })();
-  }, [texts]);
+  }, [texts, twoLinesTexts]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -62,21 +105,8 @@ export default function App() {
         <Text> Width: {PixelRatio.getPixelSizeForLayoutSize(200)}</Text>
 
         <Text>Text Result: {JSON.stringify(heights)}</Text>
-        {heights.length > 0 &&
-          texts.map((t, i) => (
-            <View key={i} style={styles.textContainer}>
-              <View
-                style={[
-                  styles.textWrapper,
-                  {
-                    height: heights[i],
-                  },
-                ]}
-              >
-                <Text style={[styles.text]}>{t}</Text>
-              </View>
-            </View>
-          ))}
+        {renderLines(heights, texts)}
+        {renderLines(twoLinesHeights, twoLinesTexts, 2)}
       </ScrollView>
     </SafeAreaView>
   );

--- a/ios/MeasureTextSize.swift
+++ b/ios/MeasureTextSize.swift
@@ -7,10 +7,15 @@ class MeasureTextSize: NSObject {
     @objc(heights:resolver:rejecter:)
     func heights(_ options: NSDictionary, resolve:RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
         let texts = RCTConvert.nsArray(options["texts"]) ?? [];
-        let optWidth = RCTConvert.float(options["width"]);
+        let optWidth = RCTConvert.cgFloat(options["width"]);
+        let optMaxLines = RCTConvert.nsInteger(options["maxLines"]);
         let optLineHeight = RCTConvert.cgFloat(options["lineHeight"]);
         let font = getFont(options)
-        let textContainer = NSTextContainer(size: CGSize(width: CGFloat(optWidth), height: CGFloat(Float.greatestFiniteMagnitude)))
+        let textContainer = NSTextContainer(size: CGSize(width: optWidth, height: CGFloat(Float.greatestFiniteMagnitude)))
+        
+        if optMaxLines > 0 {
+            textContainer.maximumNumberOfLines = optMaxLines;
+        }
         
         let paragraph = NSMutableParagraphStyle()
         if optLineHeight > 0 {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export interface MeasureOptions {
   fontWeight?: FontWeight;
   fontStyle?: FontStyle;
   lineHeight?: number;
+  maxLines?: number;
 }
 
 const { MeasureTextSize } = NativeModules;


### PR DESCRIPTION
This PR is to add maxLines option to allow to measure when user want text truncated with ellipsis.

<img src="https://user-images.githubusercontent.com/168965/162382087-53867b66-5b88-4f2c-974b-d591aa7642f1.png" width="300" />

## Usage

```typescript
const rr2 = await measureHeights({
  texts: twoLinesTexts,
  maxLines: 2, // optional param
  width,
  ...textSpec,
});
```